### PR TITLE
Install tzdata to ensure support for Lagos timezone is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Proper documentation and tests will be included soon, but you can check the [exa
 
 uv sync --extra dev
 
+uv add tzdata
+
 uv run --python 3.10 examples/main.py 1000 -OO -B
 ```
 


### PR DESCRIPTION
Without this I hit:
```
uv run --python 3.10 examples/main.py 1000 -OO -B
Traceback (most recent call last):
  File "C:\...\AppData\Roaming\uv\python\cpython-3.10.14-windows-x86_64-none\lib\zoneinfo\_common.py", line 12, in load_tzdata

...

c:\...\AppData\Roaming\uv\python\cpython-3.10.14-windows-x86_64-none\lib\zoneinfo\_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Africa/Lagos'